### PR TITLE
Convert babel preset to function for babel 7

### DIFF
--- a/babel-preset.js
+++ b/babel-preset.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = () => ({
 	sourceMaps: true,
 	plugins: [
 		[
@@ -15,4 +15,4 @@ module.exports = {
 			},
 		],
 	],
-};
+});


### PR DESCRIPTION
Fixes #5 

Given babel 7 out of beta 🎉 and react native adopting it, this is needed for new projects.