### PR TITLE
added the possibility to set the connect network

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const configureUportConnect = (config) => {
     isMobile: true,
     onloadResponse,
     useStore: false,
+    network: config.network || 'mainnet'
   })
   
   if (config.appAddress && config.privateKey) {


### PR DESCRIPTION
This is something we see as needed, if you were to use a resolver to view resolv dids on phone, there has to be a possibility to change the network as someone might be testing towards rinkeby, and attesting identities there.

Let me know if there is anything wrong with this, but this is how I use the pure connect library in our web client, targeting the right network, where we have attested a service for our identity.